### PR TITLE
fix(installer): remove grep usage for Windows compatibility

### DIFF
--- a/one_click.py
+++ b/one_click.py
@@ -330,7 +330,7 @@ class OneClick():
         # Add conda-forge channel (idempotent operation)
         # The command will fail if channel already exists, which is fine
         print("Adding conda-forge channel...")
-        cls.oc_run_cmd("conda config --add channels conda-forge 2>&1 | grep -v 'already exists' || true", environment=True)
+        cls.oc_run_cmd("conda config --add channels conda-forge", environment=True)
         
         # Set channel priority to flexible (allows packages from multiple channels)
         # This is recommended for better package resolution


### PR DESCRIPTION
fix(installer): remove grep usage for Windows compatibility in conda channel add step

Replaced the Linux-specific `grep -v 'already exists'` pipe with a direct `conda config --add channels conda-forge` call. Conda already returns success when the channel exists, so filtering is unnecessary and broke the installer on Windows (where grep is unavailable).

### Summary
This PR fixes the Windows compatibility issue in the One-Click Installer.

The installer previously ran:

    conda config --add channels conda-forge 2>&1 | grep -v 'already exists'

This fails on Windows because `grep` is not available by default. Since
`conda config --add` does not error out when the channel already exists, 
the filtering is unnecessary.

### Changes
- Removed the grep pipe and simplified the command to:
  
      conda config --add channels conda-forge

### Why This Matters
- Installer now works on Windows without requiring Git Bash or manual grep installation.
- Behavior remains correct on Linux/macOS.
