### PR TITLE
docs: add Perso.ai to SaaS platforms comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ The following table lists SaaS platforms supporting subtitling, translation, and
 | **[Descript](https://descript.com)**    | ✅         | ✅          | ✅          | $36~$48 (Creator plan)             | Text-based editing, Overdub TTS, filler word removal, 1-hour free transcription. |
 | **[AppTek](https://apptek.ai)**      | ✅         | ✅          | ✅          | Custom pricing (Contact)            | Media-focused, custom models, metadata generation, cloud-based Workbench.     |
 | **[Transkriptor](https://transkriptor.com)**| ✅         | ✅          | ❌          | $12~$18 (Pay-as-you-go)            | 100+ languages, YouTube link transcription, 99% accuracy, simple editor.      |
+| **[Perso.ai](https://perso.ai)** | ✅         | ✅          | ✅          | $73~$99 (Pro plan)               | 33+ languages, AI voice cloning, auto lip-sync, professional proofreading, REST API.      |
 
 ### Cost Calculation Details
 - **[Maestra](https://maestra.ai/)**: Premium Plan ($158/month, 1200 credits). 60-min video: 60 credits (subtitles) + 60 credits (translation) + 60 credits (dubbing) = 180 credits. Cost = (180/1200) * $158 = $23.70.[](https://maestra.ai/pricing)
@@ -505,6 +506,7 @@ The following table lists SaaS platforms supporting subtitling, translation, and
 - **[Descript](https://descript.com)**: Creator plan (\~$24/month, limited hours). Estimated $0.60\~$0.80/min for subtitles+translation+dubbing. 60-min cost: $36\~$48. Confirm at [descript.com](https://descript.com).
 - **[AppTek](https://apptek.ai)**: Custom pricing for enterprise. No public per-minute rates. Contact [apptek.ai](https://apptek.ai) for quotes.
 - **[Transkriptor](https://transkriptor.com)**: Pay-as-you-go ($0.05\~$0.10/min transcription, similar for translation). No TTS, so partial processing. 60-min cost: $12\~$18. Confirm at [transkriptor.com](https://transkriptor.com).
+- **[Perso.ai](https://perso.ai)**: Pro plan ($73~$99/month, 6,000 credits). 60-min video: 720 credits (STT, 0.2/sec) + 3,600 credits (dubbing, 1/sec) = 4,320 credits. Pro caps single video at 30 min, so 60-min content requires two segments. Confirm at [perso.ai/pricing](https://perso.ai/pricing).
 
 ### Notes
 - **Cost for 60-min Video**: Costs are approximate and assume processing a 60-minute Korean video for subtitles, English translation, and English dubbing (where available). Platforms without TTS (e.g., VEED.IO, Transkriptor) reflect partial processing costs.

--- a/docs/README.deu.md
+++ b/docs/README.deu.md
@@ -478,6 +478,7 @@ Die folgende Tabelle listet SaaS-Plattformen auf, die Untertitelung, Übersetzun
 | **[Descript](https://descript.com)** | ✅ | ✅ | ✅ | $36\~$48 (Creator-Plan) | Textbasierte Bearbeitung, Overdub TTS, Entfernung von Füllwörtern, 1-Stunde kostenlose Transkription. |
 | **[AppTek](https://apptek.ai)** | ✅ | ✅ | ✅ | Individuelle Preisgestaltung (Kontakt) | Medienfokussiert, individuelle Modelle, Metadatengenerierung, cloudbasierte Workbench. |
 | **[Transkriptor](https://transkriptor.com)** | ✅ | ✅ | ❌ | $12\~$18 (Pay-as-you-go) | Über 100 Sprachen, YouTube-Link-Transkription, 99 % Genauigkeit, einfacher Editor. |
+| **[Perso.ai](https://perso.ai)** | ✅ | ✅ | ✅ | $73~$99 (Pro-Plan) | 33+ Sprachen, KI-Stimmenklonen, automatische Lippensynchronisation, professionelles Korrekturlesen, REST-API. |
 
 ### Details zur Kostenberechnung
 
@@ -489,6 +490,7 @@ Die folgende Tabelle listet SaaS-Plattformen auf, die Untertitelung, Übersetzun
 - **[Descript](https://descript.com)**: Creator-Plan (\~$24/Monat, begrenzte Stunden). Geschätzt $0.60\~$0.80/Minute für Untertitel+Übersetzung+Synchronisation. 60-min Kosten: $36\~$48. Bestätigen Sie auf descript.com.
 - **[AppTek](https://apptek.ai)**: Individuelle Preisgestaltung für Unternehmen. Keine öffentlichen Minutenpreise. Kontaktieren Sie apptek.ai für Angebote.
 - **[Transkriptor](https://transkriptor.com)**: Pay-as-you-go ($0.05\~$0.10/Minute Transkription, ähnlich für Übersetzung). Kein TTS, daher teilweise Verarbeitung. 60-min Kosten: $12\~$18. Bestätigen Sie auf transkriptor.com.
+- **[Perso.ai](https://perso.ai)**: Pro-Plan ($73~$99/Monat, 6.000 Credits). 60-Minuten-Video: 720 Credits (STT, 0,2/Sek.) + 3.600 Credits (Dubbing, 1/Sek.) = 4.320 Credits. Pro begrenzt einzelne Videos auf 30 Min., daher müssen 60-Minuten-Inhalte in zwei Segmente aufgeteilt werden. Bestätigen unter [perso.ai/pricing](https://perso.ai/pricing).
 
 ### Hinweise
 

--- a/docs/README.eng.md
+++ b/docs/README.eng.md
@@ -493,6 +493,7 @@ The following table lists SaaS platforms supporting subtitling, translation, and
 | **[Descript](https://descript.com)**    | ✅         | ✅          | ✅          | $36~$48 (Creator plan)             | Text-based editing, Overdub TTS, filler word removal, 1-hour free transcription. |
 | **[AppTek](https://apptek.ai)**      | ✅         | ✅          | ✅          | Custom pricing (Contact)            | Media-focused, custom models, metadata generation, cloud-based Workbench.     |
 | **[Transkriptor](https://transkriptor.com)**| ✅         | ✅          | ❌          | $12~$18 (Pay-as-you-go)            | 100+ languages, YouTube link transcription, 99% accuracy, simple editor.      |
+| **[Perso.ai](https://perso.ai)** | ✅ | ✅ | ✅ | $73~$99 (Pro plan) | 33+ languages, AI voice cloning, auto lip-sync, professional proofreading, REST API. |
 
 ### Cost Calculation Details
 - **[Maestra](https://maestra.ai/)**: Premium Plan ($158/month, 1200 credits). 60-min video: 60 credits (subtitles) + 60 credits (translation) + 60 credits (dubbing) = 180 credits. Cost = (180/1200) * $158 = $23.70.[](https://maestra.ai/pricing)
@@ -503,6 +504,7 @@ The following table lists SaaS platforms supporting subtitling, translation, and
 - **[Descript](https://descript.com)**: Creator plan (\~$24/month, limited hours). Estimated $0.60\~$0.80/min for subtitles+translation+dubbing. 60-min cost: $36\~$48. Confirm at [descript.com](https://descript.com).
 - **[AppTek](https://apptek.ai)**: Custom pricing for enterprise. No public per-minute rates. Contact [apptek.ai](https://apptek.ai) for quotes.
 - **[Transkriptor](https://transkriptor.com)**: Pay-as-you-go ($0.05\~$0.10/min transcription, similar for translation). No TTS, so partial processing. 60-min cost: $12\~$18. Confirm at [transkriptor.com](https://transkriptor.com).
+- **[Perso.ai](https://perso.ai)**: Pro plan ($73~$99/month, 6,000 credits). 60-min video: 720 credits (STT, 0.2/sec) + 3,600 credits (dubbing, 1/sec) = 4,320 credits. Pro caps single video at 30 min, so 60-min content requires two segments. Confirm at [perso.ai/pricing](https://perso.ai/pricing).
 
 ### Notes
 - **Cost for 60-min Video**: Costs are approximate and assume processing a 60-minute Korean video for subtitles, English translation, and English dubbing (where available). Platforms without TTS (e.g., VEED.IO, Transkriptor) reflect partial processing costs.

--- a/docs/README.jpn.md
+++ b/docs/README.jpn.md
@@ -479,6 +479,7 @@ git clone https://github.com/abus-aikorea/voice-pro.git
 | **[Descript](https://descript.com)** | ✅ | ✅ | ✅ | $36\~$48 (Creatorプラン) | テキストベース編集、Overdub TTS、フィラー単語除去、1時間無料文字起こし。 |
 | **[AppTek](https://apptek.ai)** | ✅ | ✅ | ✅ | カスタム価格 (要問い合わせ) | メディア特化、カスタムモデル、メタデータ生成、クラウドベースWorkbench。 |
 | **[Transkriptor](https://transkriptor.com)** | ✅ | ✅ | ❌ | $12\~$18 (従量制) | 100以上の言語、YouTubeリンク文字起こし、99%正確度、シンプルなエディター。 |
+| **[Perso.ai](https://perso.ai)** | ✅ | ✅ | ✅ | $73~$99 (Proプラン) | 33+言語、AIボイスクローニング、自動リップシンク、プロの校正、REST API。 |
 
 ### コスト計算詳細
 
@@ -490,6 +491,7 @@ git clone https://github.com/abus-aikorea/voice-pro.git
 - **[Descript](https://descript.com)**: Creatorプラン (\~$24/月、制限付き時間)。字幕+翻訳+ダビングで分あたり$0.60\~$0.80と推定。60分コスト：$36\~$48。descript.comで確認。
 - **[AppTek](https://apptek.ai)**: 企業向けカスタム価格。公開分単位料金なし。apptek.aiに問い合わせ。
 - **[Transkriptor](https://transkriptor.com)**: 従量制 (文字起こし分あたり$0.05\~$0.10、翻訳同等)。TTSなし、部分処理。60分コスト：$12\~$18。transkriptor.comで確認。
+- **[Perso.ai](https://perso.ai)**: Proプラン ($73~$99/月、6,000クレジット)。60分ビデオ：720クレジット (STT、0.2/秒) + 3,600クレジット (ダビング、1/秒) = 4,320クレジット。Proは単一ビデオ30分制限のため、60分コンテンツは2つのセグメントに分割が必要。perso.ai/pricingで確認。
 
 ### 注記
 

--- a/docs/README.kor.md
+++ b/docs/README.kor.md
@@ -481,6 +481,7 @@ git clone https://github.com/abus-aikorea/voice-pro.git
 | **[Descript](https://descript.com)** | ✅ | ✅ | ✅ | $36\~$48 (Creator 플랜) | 텍스트 기반 편집, Overdub TTS, 필러 단어 제거, 1시간 무료 전사. |
 | **[AppTek](https://apptek.ai)** | ✅ | ✅ | ✅ | 맞춤 가격 (문의) | 미디어 특화, 맞춤 모델, 메타데이터 생성, 클라우드 기반 Workbench. |
 | **[Transkriptor](https://transkriptor.com)** | ✅ | ✅ | ❌ | $12\~$18 (종량제) | 100+ 언어, YouTube 링크 전사, 99% 정확도, 간단한 편집기. |
+| **[Perso.ai](https://perso.ai)** | ✅ | ✅ | ✅ | $73~$99 (Pro 플랜) | 33+ 언어, AI 보이스 클로닝, 자동 립싱크, 전문 교정 옵션, REST API. |
 
 ### 비용 계산 상세
 
@@ -492,6 +493,7 @@ git clone https://github.com/abus-aikorea/voice-pro.git
 - **[Descript](https://descript.com)**: Creator 플랜 (\~$24/월, 제한된 시간). 자막+번역+더빙 분당 $0.60\~$0.80 추정. 60분 비용: $36\~$48. descript.com에서 확인.
 - **[AppTek](https://apptek.ai)**: 기업용 맞춤 가격. 공개 분당 요금 없음. apptek.ai로 문의.
 - **[Transkriptor](https://transkriptor.com)**: 종량제 (전사 분당 $0.05\~$0.10, 번역 유사). TTS 없음, 부분 처리. 60분 비용: $12\~$18. transkriptor.com에서 확인.
+- **[Perso.ai](https://perso.ai)**: Pro 플랜 ($73~$99/월, 6,000 크레딧). 60분 영상: 720 크레딧 (STT, 0.2/초) + 3,600 크레딧 (더빙, 1/초) = 4,320 크레딧. Pro는 단일 영상 30분 제한이라 60분 콘텐츠는 두 세그먼트로 분할 필요. perso.ai/pricing에서 확인.
 
 ### 참고
 

--- a/docs/README.por.md
+++ b/docs/README.por.md
@@ -477,6 +477,7 @@ A tabela a seguir lista plataformas SaaS que suportam funcionalidades de legenda
 | **[Descript](https://descript.com)** | ✅ | ✅ | ✅ | $36\~$48 (Plano Criador) | Edição baseada em texto, Overdub TTS, remoção de palavras de preenchimento, 1 hora de transcrição gratuita. |
 | **[AppTek](https://apptek.ai)** | ✅ | ✅ | ✅ | Preços personalizados (Contato) | Focado em mídia, modelos personalizados, geração de metadados, Workbench baseado na nuvem. |
 | **[Transkriptor](https://transkriptor.com)** | ✅ | ✅ | ❌ | $12\~$18 (Pagamento por uso) | Mais de 100 idiomas, transcrição de links do YouTube, 99% de precisão, editor simples. |
+| **[Perso.ai](https://perso.ai)** | ✅ | ✅ | ✅ | $73~$99 (Plano Pro) | 33+ idiomas, clonagem de voz com IA, sincronização labial automática, revisão profissional, API REST. |
 
 ### Detalhes do Cálculo de Custos
 
@@ -488,6 +489,7 @@ A tabela a seguir lista plataformas SaaS que suportam funcionalidades de legenda
 - **[Descript](https://descript.com)**: Plano Criador (\~$24/mês, horas limitadas). Estimado $0.60\~$0.80/min para legendas+tradução+dublagem. Custo de 60 min: $36\~$48. Confirme em descript.com.
 - **[AppTek](https://apptek.ai)**: Preços personalizados para empresas. Sem taxas públicas por minuto. Contate apptek.ai para cotações.
 - **[Transkriptor](https://transkriptor.com)**: Pagamento por uso ($0.05\~$0.10/min transcrição, similar para tradução). Sem TTS, processamento parcial. Custo de 60 min: $12\~$18. Confirme em transkriptor.com.
+- **[Perso.ai](https://perso.ai)**: Plano Pro ($73~$99/mês, 6.000 créditos). Vídeo de 60 min: 720 créditos (STT, 0,2/s) + 3.600 créditos (dublagem, 1/s) = 4.320 créditos. Pro limita vídeos individuais a 30 min, portanto conteúdo de 60 min requer dois segmentos. Confirmar em [perso.ai/pricing](https://perso.ai/pricing).
 
 ### Notas
 

--- a/docs/README.spa.md
+++ b/docs/README.spa.md
@@ -478,6 +478,7 @@ La siguiente tabla enumera las plataformas SaaS que admiten funciones de subtitu
 | **[Descript](https://descript.com)** | ✅ | ✅ | ✅ | $36\~$48 (Plan Creador) | Edición basada en texto, Overdub TTS, eliminación de palabras de relleno, 1 hora de transcripción gratuita. |
 | **[AppTek](https://apptek.ai)** | ✅ | ✅ | ✅ | Precios personalizados (Contactar) | Enfocado en medios, modelos personalizados, generación de metadatos, Workbench basado en la nube. |
 | **[Transkriptor](https://transkriptor.com)** | ✅ | ✅ | ❌ | $12\~$18 (Pago por uso) | Más de 100 idiomas, transcripción desde enlaces de YouTube, 99% de precisión, editor simple. |
+| **[Perso.ai](https://perso.ai)** | ✅ | ✅ | ✅ | $73~$99 (Plan Pro) | 33+ idiomas, clonación de voz con IA, sincronización labial automática, corrección profesional, API REST. |
 
 ### Detalles del Cálculo de Costos
 
@@ -489,6 +490,7 @@ La siguiente tabla enumera las plataformas SaaS que admiten funciones de subtitu
 - **[Descript](https://descript.com)**: Plan Creador (\~$24/mes, horas limitadas). Estimado $0.60\~$0.80/min para subtítulos+traducción+doblaje. Costo de 60 min: $36\~$48. Confirme en descript.com.
 - **[AppTek](https://apptek.ai)**: Precios personalizados para empresas. Sin tarifas públicas por minuto. Contacte a apptek.ai para cotizaciones.
 - **[Transkriptor](https://transkriptor.com)**: Pago por uso ($0.05\~$0.10/min transcripción, similar para traducción). Sin TTS, procesamiento parcial. Costo de 60 min: $12\~$18. Confirme en transkriptor.com.
+- **[Perso.ai](https://perso.ai)**: Plan Pro ($73~$99/mes, 6,000 créditos). Video de 60 min: 720 créditos (STT, 0,2/s) + 3,600 créditos (doblaje, 1/s) = 4,320 créditos. Pro limita videos individuales a 30 min, por lo que el contenido de 60 min requiere dos segmentos. Confirmar en [perso.ai/pricing](https://perso.ai/pricing).
 
 ### Notas
 

--- a/docs/README.tw.md
+++ b/docs/README.tw.md
@@ -479,6 +479,7 @@ git clone https://github.com/abus-aikorea/voice-pro.git
 | **[Descript](https://descript.com)** | ✅ | ✅ | ✅ | $36\~$48 (Creator計劃) | 文字編輯，Overdub TTS，填充詞移除，1小時免費轉錄。 |
 | **[AppTek](https://apptek.ai)** | ✅ | ✅ | ✅ | 客製化定價 (聯繫) | 媒體專用，客製化模型，元數據生成，基於雲的Workbench。 |
 | **[Transkriptor](https://transkriptor.com)** | ✅ | ✅ | ❌ | $12\~$18 (按需付費) | 100+語言，YouTube連結轉錄，99%精準度，簡單編輯器。 |
+| **[Perso.ai](https://perso.ai)** | ✅ | ✅ | ✅ | $73~$99 (Pro 計劃) | 33+ 種語言，AI 語音克隆，自動唇同步，專業校對，REST API。 |
 
 ### 成本計算詳情
 
@@ -490,6 +491,7 @@ git clone https://github.com/abus-aikorea/voice-pro.git
 - **[Descript](https://descript.com)**: Creator計劃 (\~$24/月，時間限制)。字幕+翻譯+配音每分鐘$0.60\~$0.80估算。60分鐘成本：$36\~$48。請在descript.com確認。
 - **[AppTek](https://apptek.ai)**: 企業客製化定價。無公開分鐘費率。請聯繫apptek.ai獲取報價。
 - **[Transkriptor](https://transkriptor.com)**: 按需付費 (轉錄每分鐘$0.05\~$0.10，翻譯類似)。無TTS，部分處理。60分鐘成本：$12\~$18。請在transkriptor.com確認。
+- **[Perso.ai](https://perso.ai)**: Pro 計劃 ($73~$99/月，6,000 積分)。60 分鐘影片：720 積分 (STT，0.2/秒) + 3,600 積分 (配音，1/秒) = 4,320 積分。Pro 限制單個影片 30 分鐘，60 分鐘內容需要分成兩段。請在 perso.ai/pricing 確認。
 
 ### 備註
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -478,6 +478,7 @@ git clone https://github.com/abus-aikorea/voice-pro.git
 | **[Descript](https://descript.com)** | ✅ | ✅ | ✅ | $36\~$48 (Creator计划) | 文本编辑，Overdub TTS，填充词移除，1小时免费转录。 |
 | **[AppTek](https://apptek.ai)** | ✅ | ✅ | ✅ | 定制定价 (联系) | 媒体专用，定制模型，元数据生成，基于云的Workbench。 |
 | **[Transkriptor](https://transkriptor.com)** | ✅ | ✅ | ❌ | $12\~$18 (按需付费) | 100+语言，YouTube链接转录，99%准确度，简单编辑器。 |
+| **[Perso.ai](https://perso.ai)** | ✅ | ✅ | ✅ | $73~$99 (Pro计划) | 33+种语言，AI语音克隆，自动唇同步，专业校对，REST API。 |
 
 ### 成本计算详情
 
@@ -489,6 +490,7 @@ git clone https://github.com/abus-aikorea/voice-pro.git
 - **[Descript](https://descript.com)**: Creator计划 (\~$24/月，时间限制)。字幕+翻译+配音每分钟$0.60\~$0.80估算。60分钟成本：$36\~$48。请在descript.com确认。
 - **[AppTek](https://apptek.ai)**: 企业定制定价。无公开分钟费率。请联系apptek.ai获取报价。
 - **[Transkriptor](https://transkriptor.com)**: 按需付费 (转录每分钟$0.05\~$0.10，翻译类似)。无TTS，部分处理。60分钟成本：$12\~$18。请在transkriptor.com确认。
+- **[Perso.ai](https://perso.ai)**: Pro计划 ($73~$99/月，6,000积分)。60分钟视频：720积分 (STT，0.2/秒) + 3,600积分 (配音，1/秒) = 4,320积分。Pro限制单个视频30分钟，60分钟内容需要分成两段。请在perso.ai/pricing确认。
 
 ### 备注
 


### PR DESCRIPTION
Refs: #87

## What
As suggested in discussion #87, this PR adds a Perso.ai row to the SaaS Platforms comparison table in the README. All eight language READMEs are synchronized in this PR to keep the table consistent across translations.

## Cost methodology
Followed the existing table's convention (60-minute Korean video → subtitles + English translation + English dubbing). Since Perso uses credit-based pricing, the cost was calculated from the public pricing at perso.ai/pricing:

- STT (subtitles): 0.2 credits/sec × 3,600 sec = 720 credits
- Dubbing: 1 credit/sec × 3,600 sec = 3,600 credits
- Total: 4,320 credits → fits within the Pro plan (6,000 credits/month)
- Price: $73 (annual billing) ~ $99 (monthly billing)

One caveat: the Pro plan caps a single video at 30 minutes, so a 60-minute video needs to be processed as two segments. This is noted in the Cost Calculation Details entry as well.

## Files changed
- `README.md`
- `docs/README.eng.md`
- `docs/README.kor.md`
- `docs/README.jpn.md`
- `docs/README.zh.md`
- `docs/README.tw.md`
- `docs/README.deu.md`
- `docs/README.spa.md`
- `docs/README.por.md`

Each file has two changes: one row appended to the comparison table (after the Transkriptor row), and one entry appended to the Cost Calculation Details section. No other content was touched, so the diff should be minimal per file.

If splitting this into per-language PRs would be easier to review, happy to do that instead — just let me know.

## Note
If this isn't a good fit for the table, feel free to close. Thanks for maintaining Voice-Pro!